### PR TITLE
Battery level poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following Firebase parameters are available:
 | `phone_sensor_steps_interval` | int (ms) | 200 | Interval between phone step counter polls. Set to `0` to disable. |
 | `phone_sensor_acceleration_interval` | int (ms) | 200 | Interval between phone acceleration sensor polls. Set to `0` to disable. |
 | `phone_sensor_light_interval` | int (ms) | - | Set to `0` to disable. Note that the light sensor registers every change of illuminance and can't be set to record in a specific interval |
-| `phone_sensor_battery_interval` | int (s) | 60 (= 1 minute) | Interval between phone battery level polls. |
+| `phone_sensor_battery_interval_seconds` | int (s) | 600 (= 10 minutes) | Interval between phone battery level polls. |
 | **PhoneLogProvider** |||
 | `call_sms_log_interval_seconds` | int (s) | 86400 (= 1 day) | Interval for gathering Android call/sms logs. |
 | **PhoneLocationProvider** |||

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The following Firebase parameters are available:
 | `phone_sensor_magneticfield_interval` | int (ms) | 200 | Interval between phone magnetic field sensor polls. Set to `0` to disable.  |
 | `phone_sensor_steps_interval` | int (ms) | 200 | Interval between phone step counter polls. Set to `0` to disable. |
 | `phone_sensor_acceleration_interval` | int (ms) | 200 | Interval between phone acceleration sensor polls. Set to `0` to disable. |
-| `phone_sensor_light_interval` | int (ms) | 200 | Interval between phone light sensor polls. Set to `0` to disable. |
+| `phone_sensor_light_interval` | int (ms) | - | Set to `0` to disable. Note that the light sensor registers every change of illuminance and can't be set to record in a specific interval |
+| `phone_sensor_battery_interval` | int (s) | 60 (= 1 minute) | Interval between phone battery level polls. |
 | **PhoneLogProvider** |||
 | `call_sms_log_interval_seconds` | int (s) | 86400 (= 1 day) | Interval for gathering Android call/sms logs. |
 | **PhoneLocationProvider** |||

--- a/src/main/java/org/radarcns/phone/PhoneSensorManager.java
+++ b/src/main/java/org/radarcns/phone/PhoneSensorManager.java
@@ -108,7 +108,7 @@ class PhoneSensorManager extends AbstractDeviceManager<PhoneSensorService, Phone
     private PowerManager.WakeLock wakeLock;
     private Handler mHandler;
 
-    public PhoneSensorManager(PhoneSensorService context) {
+    public PhoneSensorManager(PhoneSensorService context, int batteryInterval) {
         super(context);
 
         accelerationTopic = createTopic("android_phone_acceleration", PhoneAcceleration.class);
@@ -123,7 +123,7 @@ class PhoneSensorManager extends AbstractDeviceManager<PhoneSensorService, Phone
         sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
 
         batteryProcessor = new OfflineProcessor(context, this::processBatteryStatus,
-                REQUEST_CODE_PENDING_INTENT, ACTIVITY_LAUNCH_WAKE, 6000L, true);
+                REQUEST_CODE_PENDING_INTENT, ACTIVITY_LAUNCH_WAKE, batteryInterval, true);
 
         setName(android.os.Build.MODEL);
     }

--- a/src/main/java/org/radarcns/phone/PhoneSensorProvider.java
+++ b/src/main/java/org/radarcns/phone/PhoneSensorProvider.java
@@ -26,14 +26,14 @@ import java.util.List;
 
 public class PhoneSensorProvider extends DeviceServiceProvider<PhoneState> {
     static final int PHONE_SENSOR_INTERVAL_DEFAULT = 200;
-    static final int PHONE_SENSOR_BATTERY_INTERVAL_DEFAULT = 60; // seconds
+    static final int PHONE_SENSOR_BATTERY_INTERVAL_DEFAULT_SECONDS = 600;
     static final String PHONE_SENSOR_INTERVAL = "phone_sensor_default_interval";
     static final String PHONE_SENSOR_GYROSCOPE_INTERVAL = "phone_sensor_gyroscope_interval";
     static final String PHONE_SENSOR_MAGNETIC_FIELD_INTERVAL = "phone_sensor_magneticfield_interval";
     static final String PHONE_SENSOR_STEP_COUNT_INTERVAL = "phone_sensor_steps_interval";
     static final String PHONE_SENSOR_ACCELERATION_INTERVAL = "phone_sensor_acceleration_interval";
     static final String PHONE_SENSOR_LIGHT_INTERVAL = "phone_sensor_light_interval";
-    static final String PHONE_SENSOR_BATTERY_INTERVAL = "phone_sensor_battery_interval";
+    static final String PHONE_SENSOR_BATTERY_INTERVAL_SECONDS = "phone_sensor_battery_interval_seconds";
     public static final String DEVICE_PRODUCER = "ANDROID";
     public static final String DEVICE_MODEL = "PHONE";
 
@@ -63,7 +63,7 @@ public class PhoneSensorProvider extends DeviceServiceProvider<PhoneState> {
         bundle.putInt(PHONE_SENSOR_STEP_COUNT_INTERVAL, getConfig().getInt(PHONE_SENSOR_STEP_COUNT_INTERVAL, defaultInterval));
         bundle.putInt(PHONE_SENSOR_ACCELERATION_INTERVAL, getConfig().getInt(PHONE_SENSOR_ACCELERATION_INTERVAL, defaultInterval));
         bundle.putInt(PHONE_SENSOR_LIGHT_INTERVAL, getConfig().getInt(PHONE_SENSOR_LIGHT_INTERVAL, defaultInterval));
-        bundle.putInt(PHONE_SENSOR_BATTERY_INTERVAL, getConfig().getInt(PHONE_SENSOR_BATTERY_INTERVAL, PHONE_SENSOR_BATTERY_INTERVAL_DEFAULT));
+        bundle.putInt(PHONE_SENSOR_BATTERY_INTERVAL_SECONDS, getConfig().getInt(PHONE_SENSOR_BATTERY_INTERVAL_SECONDS, PHONE_SENSOR_BATTERY_INTERVAL_DEFAULT_SECONDS));
     }
 
     @Override

--- a/src/main/java/org/radarcns/phone/PhoneSensorProvider.java
+++ b/src/main/java/org/radarcns/phone/PhoneSensorProvider.java
@@ -32,6 +32,7 @@ public class PhoneSensorProvider extends DeviceServiceProvider<PhoneState> {
     static final String PHONE_SENSOR_STEP_COUNT_INTERVAL = "phone_sensor_steps_interval";
     static final String PHONE_SENSOR_ACCELERATION_INTERVAL = "phone_sensor_acceleration_interval";
     static final String PHONE_SENSOR_LIGHT_INTERVAL = "phone_sensor_light_interval";
+    static final String PHONE_SENSOR_BATTERY_INTERVAL = "phone_sensor_battery_interval";
     public static final String DEVICE_PRODUCER = "ANDROID";
     public static final String DEVICE_MODEL = "PHONE";
 
@@ -61,6 +62,7 @@ public class PhoneSensorProvider extends DeviceServiceProvider<PhoneState> {
         bundle.putInt(PHONE_SENSOR_STEP_COUNT_INTERVAL, getConfig().getInt(PHONE_SENSOR_STEP_COUNT_INTERVAL, defaultInterval));
         bundle.putInt(PHONE_SENSOR_ACCELERATION_INTERVAL, getConfig().getInt(PHONE_SENSOR_ACCELERATION_INTERVAL, defaultInterval));
         bundle.putInt(PHONE_SENSOR_LIGHT_INTERVAL, getConfig().getInt(PHONE_SENSOR_LIGHT_INTERVAL, defaultInterval));
+        bundle.putInt(PHONE_SENSOR_BATTERY_INTERVAL, getConfig().getInt(PHONE_SENSOR_BATTERY_INTERVAL, defaultInterval));
     }
 
     @Override

--- a/src/main/java/org/radarcns/phone/PhoneSensorProvider.java
+++ b/src/main/java/org/radarcns/phone/PhoneSensorProvider.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 public class PhoneSensorProvider extends DeviceServiceProvider<PhoneState> {
     static final int PHONE_SENSOR_INTERVAL_DEFAULT = 200;
+    static final int PHONE_SENSOR_BATTERY_INTERVAL_DEFAULT = 60; // seconds
     static final String PHONE_SENSOR_INTERVAL = "phone_sensor_default_interval";
     static final String PHONE_SENSOR_GYROSCOPE_INTERVAL = "phone_sensor_gyroscope_interval";
     static final String PHONE_SENSOR_MAGNETIC_FIELD_INTERVAL = "phone_sensor_magneticfield_interval";
@@ -62,7 +63,7 @@ public class PhoneSensorProvider extends DeviceServiceProvider<PhoneState> {
         bundle.putInt(PHONE_SENSOR_STEP_COUNT_INTERVAL, getConfig().getInt(PHONE_SENSOR_STEP_COUNT_INTERVAL, defaultInterval));
         bundle.putInt(PHONE_SENSOR_ACCELERATION_INTERVAL, getConfig().getInt(PHONE_SENSOR_ACCELERATION_INTERVAL, defaultInterval));
         bundle.putInt(PHONE_SENSOR_LIGHT_INTERVAL, getConfig().getInt(PHONE_SENSOR_LIGHT_INTERVAL, defaultInterval));
-        bundle.putInt(PHONE_SENSOR_BATTERY_INTERVAL, getConfig().getInt(PHONE_SENSOR_BATTERY_INTERVAL, defaultInterval));
+        bundle.putInt(PHONE_SENSOR_BATTERY_INTERVAL, getConfig().getInt(PHONE_SENSOR_BATTERY_INTERVAL, PHONE_SENSOR_BATTERY_INTERVAL_DEFAULT));
     }
 
     @Override

--- a/src/main/java/org/radarcns/phone/PhoneSensorService.java
+++ b/src/main/java/org/radarcns/phone/PhoneSensorService.java
@@ -40,6 +40,7 @@ import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_BATTERY_INTERV
  */
 public class PhoneSensorService extends DeviceService<PhoneState> {
     private SparseIntArray sensorDelays;
+    private int batteryInterval;
 
     @Override
     public void onCreate() {
@@ -49,7 +50,7 @@ public class PhoneSensorService extends DeviceService<PhoneState> {
 
     @Override
     protected PhoneSensorManager createDeviceManager() {
-        PhoneSensorManager manager = new PhoneSensorManager(this);
+        PhoneSensorManager manager = new PhoneSensorManager(this, batteryInterval);
         manager.setSensorDelays(sensorDelays);
         return manager;
     }
@@ -67,10 +68,11 @@ public class PhoneSensorService extends DeviceService<PhoneState> {
         sensorDelays.put(Sensor.TYPE_GYROSCOPE, bundle.getInt(PHONE_SENSOR_GYROSCOPE_INTERVAL));
         sensorDelays.put(Sensor.TYPE_LIGHT, bundle.getInt(PHONE_SENSOR_LIGHT_INTERVAL));
         sensorDelays.put(Sensor.TYPE_STEP_COUNTER, bundle.getInt(PHONE_SENSOR_STEP_COUNT_INTERVAL));
+        batteryInterval = bundle.getInt(PHONE_SENSOR_BATTERY_INTERVAL);
         PhoneSensorManager manager = (PhoneSensorManager) getDeviceManager();
         if (manager != null) {
             manager.setSensorDelays(sensorDelays);
-            manager.setBatteryUpdateInterval(bundle.getInt(PHONE_SENSOR_BATTERY_INTERVAL));
+            manager.setBatteryUpdateInterval(batteryInterval);
         }
     }
 

--- a/src/main/java/org/radarcns/phone/PhoneSensorService.java
+++ b/src/main/java/org/radarcns/phone/PhoneSensorService.java
@@ -32,6 +32,7 @@ import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_GYROSCOPE_INTE
 import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_LIGHT_INTERVAL;
 import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_MAGNETIC_FIELD_INTERVAL;
 import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_STEP_COUNT_INTERVAL;
+import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_BATTERY_INTERVAL;
 
 /**
  * A service that manages the phone sensor manager and a TableDataHandler to send store the data of
@@ -69,6 +70,7 @@ public class PhoneSensorService extends DeviceService<PhoneState> {
         PhoneSensorManager manager = (PhoneSensorManager) getDeviceManager();
         if (manager != null) {
             manager.setSensorDelays(sensorDelays);
+            manager.setBatteryUpdateInterval(bundle.getInt(PHONE_SENSOR_BATTERY_INTERVAL));
         }
     }
 

--- a/src/main/java/org/radarcns/phone/PhoneSensorService.java
+++ b/src/main/java/org/radarcns/phone/PhoneSensorService.java
@@ -19,20 +19,15 @@ package org.radarcns.phone;
 import android.hardware.Sensor;
 import android.os.Bundle;
 import android.util.SparseIntArray;
-import org.apache.avro.specific.SpecificRecord;
-import org.radarcns.android.device.DeviceService;
-import org.radarcns.kafka.ObservationKey;
-import org.radarcns.topic.AvroTopic;
 
-import java.util.Arrays;
-import java.util.List;
+import org.radarcns.android.device.DeviceService;
 
 import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_ACCELERATION_INTERVAL;
 import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_GYROSCOPE_INTERVAL;
 import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_LIGHT_INTERVAL;
 import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_MAGNETIC_FIELD_INTERVAL;
 import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_STEP_COUNT_INTERVAL;
-import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_BATTERY_INTERVAL;
+import static org.radarcns.phone.PhoneSensorProvider.PHONE_SENSOR_BATTERY_INTERVAL_SECONDS;
 
 /**
  * A service that manages the phone sensor manager and a TableDataHandler to send store the data of
@@ -68,7 +63,7 @@ public class PhoneSensorService extends DeviceService<PhoneState> {
         sensorDelays.put(Sensor.TYPE_GYROSCOPE, bundle.getInt(PHONE_SENSOR_GYROSCOPE_INTERVAL));
         sensorDelays.put(Sensor.TYPE_LIGHT, bundle.getInt(PHONE_SENSOR_LIGHT_INTERVAL));
         sensorDelays.put(Sensor.TYPE_STEP_COUNTER, bundle.getInt(PHONE_SENSOR_STEP_COUNT_INTERVAL));
-        batteryInterval = bundle.getInt(PHONE_SENSOR_BATTERY_INTERVAL);
+        batteryInterval = bundle.getInt(PHONE_SENSOR_BATTERY_INTERVAL_SECONDS);
         PhoneSensorManager manager = (PhoneSensorManager) getDeviceManager();
         if (manager != null) {
             manager.setSensorDelays(sensorDelays);


### PR DESCRIPTION
Poll the battery level at a fixed interval, using the latest `ACTION_BATTERY_CHANGED` intent.
Also cache the data if it can't be send (e.g. due to loss of network connectivity).